### PR TITLE
Fix accessibility: Remove icon carousel from tab navigation

### DIFF
--- a/carousel.js
+++ b/carousel.js
@@ -264,7 +264,7 @@ export function moveCarousel(type, dir) {
 
 export function renderIconCarousel(iconOptions, currentIcon) {
   const idx = iconOptions.indexOf(currentIcon);
-  let html = `<div class="carousel-items" style="display:inline-block;overflow-x:auto;white-space:nowrap;width:280px;vertical-align:middle;padding:4px;" role="listbox" aria-label="Icon options">`;
+  let html = `<div class="carousel-items" style="display:inline-block;overflow-x:auto;white-space:nowrap;width:280px;vertical-align:middle;padding:4px;" role="listbox" aria-label="Icon options" tabindex="-1">`;
   iconOptions.forEach((icon, i) => {
     const selected = i === idx;
     const fill = selected ? '#555' : '#bbb';


### PR DESCRIPTION
## Summary
- Fixes issue #11 where the icon carousel container was incorrectly included in tab navigation
- Adds `tabindex="-1"` to the icon carousel container to prevent it from being focusable via Tab key
- Individual icons remain fully accessible via arrow keys and click interactions

## Changes
- Modified `carousel.js` line 267 to add `tabindex="-1"` to the icon carousel container
- This matches the existing pattern already used for shield and ribbon carousels

## Testing
- Icon carousel is no longer included in tab order
- Arrow key navigation still works correctly
- Individual icons remain clickable and accessible
- Screen readers can still access icon information through ARIA labels

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)